### PR TITLE
Simplify pattern set processing and evaluation - move from a black/white evaluation to a mover/empty one.

### DIFF
--- a/src/Evaluator.h
+++ b/src/Evaluator.h
@@ -54,8 +54,8 @@ protected:
 
 private:
 	CEvaluator(const std::string& fnBase, int nFiles);
-	TCoeff *coeffs[60][2];
-	TCoeff *pcoeffs[60][2];
+	TCoeff *coeffs[60];
+	TCoeff *pcoeffs[60];
 	int	nEmptyToSet[60];
 	u4  fParameters[60];
 	int nSets;

--- a/src/randomEvalGen.cpp
+++ b/src/randomEvalGen.cpp
@@ -2,6 +2,8 @@
 //	All Rights Reserved
 // This file is distributed subject to GNU GPL version 3. See the files
 // GPLv3.txt and License.txt in the instructions subdirectory for details.
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 #include <cstdio>
 #include <cstdlib>
@@ -54,7 +56,7 @@ void RandomGameEvalGen() {
                 Pos2 pp;
                 pp.Initialize(bb, blackMove);
                 CValue val = eval->EvalMobs(pp, bitCount(moveBits), bitCount(enemyMoveBits));
-                fprintf(stdout, "{0x%llx, 0x%llx, %s, %d} /* %d moves */", bb.mover, bb.empty, blackMove? "true": "false", static_cast<int>(val), stopAt);
+                fprintf(stdout, "{0x%" PRIx64 ", 0x%" PRIx64 ", %s, %d} /* %d moves */", bb.mover, bb.empty, blackMove? "true": "false", static_cast<int>(val), stopAt);
                 break;
             }
             // Perform the move.
@@ -78,6 +80,11 @@ void RandomGameEvalGen() {
             }
         }
     } while (!gameOver);
+}
+
+// To satisfy linker in debug mode
+bool HasInput() {
+    return false;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
I've also made some minor fixes to randomEvalGen.

BTW, there's no noticeable speed benefit. I mean, you're absolutely right that reducing the data size can reduce cache misses. "Problem" is that there weren't many cache misses to begin with.

In any case, it's worth it to simplify the code a little bit, and also to reduce the memory consumption slightly.

Also, I should say thank you for insisting on the evaluator test. It was remarkably helpful :).
